### PR TITLE
Make unpack_off() handle values > 2GiB. Fixes #2.

### DIFF
--- a/museeq/museekmessages.h
+++ b/museeq/museekmessages.h
@@ -105,7 +105,7 @@ public:
 	qint64 unpack_off() {
 		qint64 r = 0;
 		for(int j = 0; j < 8; j++)
-			r += unpack() << (j * 8);
+			r += (qint64)unpack() << (j * 8);
 		return r;
 	}
 	QString unpack_str() {


### PR DESCRIPTION
This fixes the problem of files larger than 2GiB appearing with negative sizes, so long as museekd reports the correct size. This accounts for the cases where other museekd clients were reporting the correct size while museeq was not.

However, some files are still shown with negative sizes in museeq, while the same files are shown with unbelievably large sizes (0xFFFFFFFF........) in other museekd clients. Since this happens on a per-peer basis, it seems that the bug lies either in those peers or in museekd's interpretation of their
messages; I'm not sure which yet. The current official SoulseekQt doesn't show any files > 2GiB in its search & browse results, so I have no way to be sure which peers are reporting large file sizes as the Soulseek developer intended, but a look at the raw messages from a problematic peer ought to give a strong indication.