### PR TITLE
Write incomplete files in the correct download dirs.

### DIFF
--- a/museekd/downloadmanager.cpp
+++ b/museekd/downloadmanager.cpp
@@ -101,6 +101,9 @@ Museek::Download::incompletePath() const
 
     // Get the incomplete directory
     std::string incompletedir = m_Museekd->config()->get("transfers", "incomplete-dir");
+    // Fall back to the destination directory provided with the download.
+    if(incompletedir.empty() && NewNet::Path(m_LocalDir).isAbsolute())
+        incompletedir = m_LocalDir;
     // Fall back to download directory.
     if(incompletedir.empty())
         incompletedir = m_Museekd->config()->get("transfers", "download-dir");


### PR DESCRIPTION
The prompts in musetup say that if the user configures no "incomplete downloads" directory, museekd is supposed to place incomplete files in "completed download dirs". However, museekd was placing all incomplete files in the general download directory instead of the transfer-specific download directories, so it didn't work as expected. (It also made incomplete file conflicts more common, because different transfers with the same file name would end up being written to the same temporary file.)

This patch makes museekd behave as musetup indicates, that is, it now uses a transfer's completed download directory for temporary/incomplete files when no general "incomplete downloads" directory has been configured. It falls back to the general download directory when a transfer doesn't have one of its own.