### PR TITLE
Let umask determine group permissions on new dirs.

### DIFF
--- a/museekd/util.h
+++ b/museekd/util.h
@@ -52,7 +52,7 @@ static inline bool makedirs(const std::string & dir)
       continue;
     // Create the piece of the path.
 #ifndef WIN32
-    if(mkdir(path.c_str(), S_IRWXU | S_IRGRP | S_IXGRP | S_IROTH | S_IXOTH) == -1 && errno != EEXIST)
+    if(mkdir(path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH) == -1 && errno != EEXIST)
 #else
     if(mkdir(path.c_str()) == -1 && errno != EEXIST)
 #endif // ! WIN32


### PR DESCRIPTION
When creating new directories, museekd was ignoring my umask, leaving my group without write permission to the new dirs. It forced me to continually correct the permissions on these directories, which was an irritating hassle. This patch makes museekd respect the umask for group write permissions.