### PR TITLE
mucous: fix index oob when parsing search results

### DIFF
--- a/mucous/pymucous/MucousSearch.py
+++ b/mucous/pymucous/MucousSearch.py
@@ -474,13 +474,9 @@ class Search:
 			for numbers, results in self.results[str(this_ticket)].items():
 				ticket, user, free, speed, queue, path, size, ftype, extended = results
 				if this_ticket == ticket and self.current == ticket:
-					if ftype.upper() in ('MP3', 'OGG'):
-						if extended != []:
-							bitrate = extended[0]
-							time = extended[1]
-						else:
-							bitrate = 0
-							time = 0
+					if ftype.upper() in ('MP3', 'OGG') and extended != []:
+						bitrate = extended[0]
+						time = extended[1] if len(extended) > 1 else 0
 					else: 
 						bitrate = 0
 						time = 0


### PR DESCRIPTION
Fixes an occasional index-out-of-bounds runtime error encountered when
parsing 'extra' info (bitrate and time) from OGG / MP3 search results.

Signed-off-by: Quentin Young <qlyoung@qlyoung.net>