### PR TITLE
mucous: fix display corruption when searching

### DIFF
--- a/mucous/pymucous/MucousSearch.py
+++ b/mucous/pymucous/MucousSearch.py
@@ -412,7 +412,7 @@ class Search:
 				ssw.erase()
 				ssw.addstr(self.mucous.logs["search_count"][0],  self.mucous.colors["blackwhite"] )
 				ssw.addstr(str(self.mucous.logs["search_count"][1]),  self.mucous.colors["blackwhite"] )
-				ssw.refresh()
+				ssw.noutrefresh()
 			except Exception, e:
 				pass
 				#self.mucous.Help.Log( "debug", "Search Status: " + str(e))


### PR DESCRIPTION
This fixes a longstanding bug whereby the curses display would become corrupted
while updating itself to display results for a search. The culprit turned out
to be a hard refresh() call on the "Results: N" counter in the title bar, where
it should have been a noutrefresh().

This should help with the resolution of #14.

Signed-off-by: Quentin Young <qlyoung@qlyoung.net>