### PR TITLE
Fix folder downloading in `museekcontrol`

### DIFF
--- a/python-clients/museekcontrol
+++ b/python-clients/museekcontrol
@@ -601,7 +601,7 @@ class museekcontrol(driver.Driver):
 			elif want == "downfolder":
 				if user != '':
 					s = ufile[:-1]
-					self.send(messages.GetFolderContents(user, ufile))
+					self.send(messages.GetFolderContents(user, s))
 						
 				sys.exit()
 			elif want == "gsearch":


### PR DESCRIPTION
Downloading a folder with `museekcontrol` doesn't work. This is because `messages.GetFolderContents` is being called with the path to the folder that includes a trailing forward slash.

There is actually a variable (`s`) directly above the call to `messages.GetFolderContents` that removed the trailing slash from `ufile`, but it wasn't actually being used. I updated the code to use it, and that fixed it.

Fixes #43.