### PR TITLE
Avoid segmentation fault in NewNet Reactor

### DIFF
--- a/NewNet/nnreactor.cpp
+++ b/NewNet/nnreactor.cpp
@@ -218,7 +218,10 @@ NewNet::Reactor::prepareReactorData() {
         timeout.tv_usec = 0;
       }
 
-      evtimer_del(&mEvTimeout); // delete potentially existing previous timeout
+      // Delete potentially existing previous timeout
+      if (event_initialized(&mEvTimeout))
+        evtimer_del(&mEvTimeout);
+
       evtimer_set(&mEvTimeout, ::eventCallback, this);
       evtimer_add(&mEvTimeout, &timeout);
     }


### PR DESCRIPTION
Seems like this started occurring after a libevent update/change in early 2020, and prevents museekd from starting.
https://aur.archlinux.org/packages/museekd-git#comment-742554