### PR TITLE
README.md: Add links to actively maintained clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,15 @@
 # Museek Plus
 
+## No longer maintained!
+
+Museek+ is no longer in active development. Please use one of the actively maintained alternatives to avoid compatibility issues with other Soulseek clients:
+
+- [slskd](https://github.com/slskd/slskd), a modern client-server application
+- [Nicotine+](https://nicotine-plus.org/), a graphical client for desktop
+- [Seeker](https://github.com/jackBonadies/SeekerAndroid), a client for Android
+
+## Setup
+
 Website for ticket, documentation and packages is http://www.museek-plus.org
 
 **Museek** consists of the binary progams: 


### PR DESCRIPTION
Museek+ is effectively 10-15 years behind on Soulseek developments (except for a few commits from lbponey in 2017). Unless someone steps up to fix bugs and keep Museek+ up to modern standards, advice users to use other clients instead.